### PR TITLE
修改了有时会按键误判的bug

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -416,7 +416,7 @@ function click(index) {
     let id = p.id.substring(0, 11) + num;
 
     let fakeEvent = {
-        clientX: ((index - 1) * blockSize + index * blockSize) / 2,
+        clientX: ((index - 1) * blockSize + index * blockSize) / 2 + body.offsetLeft,
         // Make sure that it is in the area
         clientY: (touchArea[0] + touchArea[1]) / 2,
         target: document.getElementById(id),


### PR DESCRIPTION
之前再模拟鼠标点击x坐标的时候, 没有加上offsetLeft
导致有时会误判