### PR TITLE
🔧修改自定义按键非小写就无效的问题

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -386,10 +386,10 @@ function initSetting() {
     if(cookie("keyboard")){
         document.getElementById("keyboard").value = cookie("keyboard");
         map={}
-        map[cookie("keyboard").charAt(0)]=1;
-        map[cookie("keyboard").charAt(1)]=2;
-        map[cookie("keyboard").charAt(2)]=3;
-        map[cookie("keyboard").charAt(3)]=4;
+        map[cookie("keyboard").charAt(0).toLowerCase()]=1;
+        map[cookie("keyboard").charAt(1).toLowerCase()]=2;
+        map[cookie("keyboard").charAt(2).toLowerCase()]=3;
+        map[cookie("keyboard").charAt(3).toLowerCase()]=4;
     }
 }
 function show_btn() {


### PR DESCRIPTION
之前如果自定义设置时写大写就会无效